### PR TITLE
Fix missing dependency (qs). Improve installation-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sierra-wrapper
 
-A basic node wrapper for the [III Sierra v3 API](https://sandbox.iii.com/docs/Content/titlePage.htm)
+A basic node wrapper for the [III Sierra v3/v6 API](https://sandbox.iii.com/docs/Content/titlePage.htm)
 
 The wrapper currently supports:
 
@@ -15,9 +15,14 @@ request:
 - get
 - post
 
-More endpoint will be added as the need arises.
+## Usage
 
----
+Load the client as follows:
+```
+const wrapper = require('@nypl/sierra-wrapper')
+```
+
+### Authenticating
 
 To configure credentials there are three options:
 
@@ -46,9 +51,23 @@ wrapper.config(options)
 
 3. You can also set your credentials via environment variables: `SIERRA_KEY`, `SIERRA_SECRET`, `SIERRA_BASE`
 
-----
+### Querying
 
-## config(configOrFile) ⇒ <code>boolean</code>
+The following retrieves a bunch of bib ids:
+
+```
+const printBibIds = async () => {
+  try {
+    const bibs = await wrapper.get('bibs')
+    console.log('Got bibs:', bibs.entries.map(b => b.id))
+  } catch (e) {
+    console.log(e.message)
+  }
+}
+```
+
+## API
+### config(configOrFile) ⇒ <code>boolean</code>
 Loads a config object, passed or from disk
 **Returns**: <code>boolean</code> - did it load or not
 
@@ -56,17 +75,17 @@ Loads a config object, passed or from disk
 | --- | --- | --- |
 | configOrFile | <code>object</code> &#124; <code>string</code> | The object with the credentials or a path to a json file with the credentials |
 
-## authenticate()
-Requests an auth token from the sierra API and stores it for future use. It automatically reattempts when there is an empty response from Sierra (a not uncommon error).
+### authenticate()
+Called internally to retrieve an access token before all calls. Requests an auth token from the sierra API and stores it for future use. It automatically reattempts when there is an empty response from Sierra (a not uncommon error).
 
-## get(path)
+### get(path)
 Makes a get request to ${exports.credsBase}${path} and returns the response. It automatically reattempts when there is an empty response from Sierra (a not uncommon error).
 
 resolves to the result:
 
 {"id":1001006,"expirationDate":"2019-01-07","patronType":10,"patronCodes":{"pcode1":"-","pcode2":"-","pcode3":2,"pcode4":0},"homeLibraryCode":"hd","message":{"code":"-","accountMessages":["LBR6@columbia.edu"]}
 
-## post(path, data)
+### post(path, data)
 Makes a post request to ${exports.credsBase}${path} and returns the response
 
 resolves to the result:
@@ -77,7 +96,7 @@ resolves to the result:
 	name: 'XCirc error',
 	description: 'XCirc error : Bib record cannot be loaded' }
 
-## getSingleBib(bibId)
+### getSingleBib(bibId)
 Requests a single bib data from the API
 
 Return format:
@@ -87,7 +106,7 @@ Return format:
 | --- | --- | --- |
 | bibId | <code>string</code> | the bnumber of the bib you want to request |
 
-## getRangeBib(bibIdStart, bibIdEnd)
+### getRangeBib(bibIdStart, bibIdEnd)
 Requests a bib range from the API
 
 Return format:
@@ -98,7 +117,7 @@ Return format:
 | bibIdStart | <code>string</code> | the bnumber of the bib you want to request |
 | bibIdEnd | <code>string</code> | the bnumber of the bib you want to request |
 
-## getRangeItem(itemIdStart, itemIdEnd)
+### getRangeItem(itemIdStart, itemIdEnd)
 Requests an item range from the API
 
 Return format:
@@ -109,7 +128,7 @@ Return format:
 | itemIdStart | <code>string</code> | the bnumber of the bib you want to request |
 | itemIdEnd | <code>string</code> | the bnumber of the bib you want to request |
 
-## getBibItems(bibId)
+### getBibItems(bibId)
 Requests all the items of a specified bib id
 Return format:
 [ [Object], [Object] ]
@@ -118,7 +137,7 @@ Return format:
 | --- | --- | --- |
 | bibId | <code>string</code> | the bnumber of the bib you want to request |
 
-## getMultiBibBasic(bibsIds)
+### getMultiBibBasic(bibsIds)
 Requests multiple bibs, but no orders or locations
 
 Return format:
@@ -129,7 +148,7 @@ Return format:
 | bibsIds | <code>array</code> | an array of bib id strings |
 
 
-## getMultiItemBasic(itemIds)
+### getMultiItemBasic(itemIds)
 Requests multiple items
 
 Return format:
@@ -146,3 +165,11 @@ Return format:
 3. After PR is approved, run npm publish
 4. Go to your package page (https://npmjs.com/package/<package>) to check that the package version has been updated
 
+## Testing
+
+Run unit tests via:
+```
+npm test
+```
+
+See [./test/installation-test](./test/installation-test) for scripts to validate a release before publication.

--- a/package-lock.json
+++ b/package-lock.json
@@ -467,7 +467,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1420,8 +1419,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1445,7 +1443,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1549,7 +1546,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1569,8 +1565,7 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -2337,8 +2332,7 @@
     "object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -2695,10 +2689,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -2778,6 +2774,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -3056,7 +3060,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "axios": "^0.25.0",
     "highland": "^2.8.1",
+    "qs": "^6.10.3",
     "should": "^13.2.3",
     "winston": "^3.5.1"
   },

--- a/test/installation-test/README.md
+++ b/test/installation-test/README.md
@@ -3,7 +3,11 @@
 These are installation tests for testing updates to the client.
 
  * Ready a feature branch of the client (e.g. SCC-123)
- * `cd test/installation-tests`
+ * COPY the whole folder into a different tree to ensure `node_modules` of a parent directory does't cascade\*:
+   - e.g. ```cp -R `pwd`/test/installation-test /tmp/sierra-wrapper-installation-test```
+ * `cd /tmp/sierra-wrapper-installation-test`
  * Update `package.json` to use the branch tag (e.g. ".../sierra-wrapper.git#SCC-123")
  * `npm i`
  * See `./test-with-*` scripts
+
+ \* See [Nodejs.org Loading from node_modules folders](https://nodejs.org/dist/latest-v12.x/docs/api/all.html#modules_loading_from_node_modules_folders). If a required module isn't found in the current app's `node_modules` directory, Node.js looks for a `node_modules` directory in each of the parent directories. We don't want a required module to resolve to the one installed in a parent `node_modules` directory; We want these installation tests to run in a clean environment so that we can catch missing dependencies.

--- a/test/installation-test/test-with-env-creds.js
+++ b/test/installation-test/test-with-env-creds.js
@@ -10,7 +10,6 @@
  */
 const wrapper = require('@nypl/sierra-wrapper')
 
-// It would be nice to be able to set logLevel as follows:
 wrapper.setLogLevel('error')
 
 const run = async () => {


### PR DESCRIPTION
Fixes bug where module doesn't specify `qs` as a non-dev dependency.
When running the module locally with dev dependencies, `mocha` includes
`qs` as a dependency, so tests pass. Our previous strategy for doing an
"installation test" missed the missing dependency because `require`
searches parent directories for `node_modules` too!